### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,13 +2,13 @@ import PackageDescription
 
 let package = Package(
     name: "Quick",
-    exclude: [
-      "Sources/QuickObjectiveC"
-    ],
     // TODO: Once the `test` command has been implemented in the Swift Package Manager, this should be changed to
     // be `testDependencies:` instead. For now it has to be done like this for the library to get linked with the test targets.
     // See: https://github.com/apple/swift-evolution/blob/master/proposals/0019-package-manager-testing.md
     dependencies: [
         .Package(url: "https://github.com/norio-nomura/Nimble", "5.0.0-alpha.30p2")
+    ],
+    exclude: [
+      "Sources/QuickObjectiveC"
     ]
 )


### PR DESCRIPTION
The Swift Package Manager wants `dependencies:` to precede `exclude:` in the parameter list.
